### PR TITLE
adding parallel execution via scala futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An experimental DAG library with support for FP scala and its associated FP libraries.
 
-## Usage Example 
+## Usage Example
+
+1. Lazy Evaluation 
 ```scala
   // establish operators
   def read[A](): A
@@ -37,4 +39,21 @@ An experimental DAG library with support for FP scala and its associated FP libr
   // run if needed
   network("output1").getValue()
   network("output2").getValue()
+```
+
+2. Parallel Execution
+
+```scala
+ // build network
+ val futureNetwork = DAGNode.toFutureNetWork(nodes)
+ /**
+  * input1 ---> process1 ---> output1
+  *         |             |
+  *         v             v
+  * input2 ---> process2 ---> output2
+  */
+ 
+ // run if needed
+ futureNetwork("output1").getFuture()
+ futureNetwork("output2").getFuture()
 ```

--- a/src/main/scala/github/dmarticus/dag/LazyNode.scala
+++ b/src/main/scala/github/dmarticus/dag/LazyNode.scala
@@ -1,5 +1,9 @@
 package github.dmarticus.dag
 
+import github.dmarticus.dag.DAGNode.LazyFuture
+
+import scala.concurrent.Future
+
 case class LazyNode[+A](getValue: () => A) {
   import LazyNode._
 
@@ -22,4 +26,6 @@ object LazyNode {
 
   def sequence[A](as: Seq[LazyNode[A]]): LazyNode[Seq[A]] =
     lazyNode(as.map(_.getValue()))
+
+  implicit def asLazyFuture[A](l: LazyNode[Future[A]]): LazyFuture[A] = LazyFuture(l)
 }

--- a/src/test/scala/github/dmarticus/dag/LazyNodeTest.scala
+++ b/src/test/scala/github/dmarticus/dag/LazyNodeTest.scala
@@ -2,9 +2,10 @@ package github.dmarticus.dag
 
 import java.util.concurrent.ConcurrentHashMap
 
+import github.dmarticus.dag.common.TestHelpers
 import org.scalatest.funspec.AnyFunSpec
 
-class LazyNodeTest extends AnyFunSpec {
+class LazyNodeTest extends AnyFunSpec with TestHelpers {
   describe("For any node of the directed network,") {
     it("is lazy and evaluated only once.") {
       /* ------- records for method execute times --------- */
@@ -52,10 +53,10 @@ class LazyNodeTest extends AnyFunSpec {
       val nodes =
         Seq(input1, input2, input3, process1, process2, output1, output2)
 
-      val m: Map[String, LazyNode[Int]] = DAGNode.toLazyNetWork(nodes)
-      assert(m.size === 7)
+      val network: Map[String, LazyNode[Int]] = DAGNode.toLazyNetWork(nodes)
+      assert(network.size === 7)
 
-      m("o1").getValue()
+      network("o1").getValue()
       assert(records.values().toArray().forall(_ === 1))
       assert(records.size === 4)
       assert(records.containsKey("p2"))
@@ -63,13 +64,46 @@ class LazyNodeTest extends AnyFunSpec {
       assert(records.containsKey("i2"))
       assert(records.containsKey("i3"))
 
-      m("o2").getValue()
+      network("o2").getValue()
       assert(records.values().toArray().forall(_ === 1))
-      assert(records.size === m.size)
+      assert(records.size === network.size)
 
-      assert(m("p1").getValue() === 2)
-      assert(m("p2").getValue() === 5)
+      assert(network("p1").getValue() === 2)
+      assert(network("p2").getValue() === 5)
       assert(records.values().toArray().forall(_ === 1))
     }
   }
-}
+  describe("For lazy evaluation of a concurrent network") {
+    it("nodes are only evaluated once") {
+      val nodes = Seq(InputNode("input", () => System.currentTimeMillis()))
+      val futureNetwork = DAGNode.toFutureNetwork(nodes)
+
+      val before = futureNetwork("input").getFuture()
+      Thread.sleep(1)
+      val after = futureNetwork("input").getFuture()
+
+      assert(before === after)
+    }
+
+    it("nodes are executed in parallel") {
+      // build network
+      val input1 = InputNode("input1", read("input1", 0))
+      val input2 = InputNode("input2", read("input2", 100))
+      val input3 = InputNode("input3", read("input3", 50))
+      val process1 = InternalNode(
+        "process1",
+        Seq("input1", "input2", "input3"),
+        process("process1"))
+
+      val nodes = Seq(input1, input2, input3, process1)
+      val futureNetwork = DAGNode.toFutureNetwork(nodes)
+
+      assert(
+        futureNetwork("process1").getFuture()
+          .sortBy(_.start)
+          .sliding(2)
+          .exists(x => x(1).start < x(0).end))
+    }
+  }
+
+  }

--- a/src/test/scala/github/dmarticus/dag/common/TestHelpers.scala
+++ b/src/test/scala/github/dmarticus/dag/common/TestHelpers.scala
@@ -1,0 +1,22 @@
+package github.dmarticus.dag.common
+
+case class ExecutionTimestamp(id: String, start: Long, end: Long)
+
+trait TestHelpers {
+
+  val TIMEOUT_IN_MS = 10
+  val RUNTIME_IN_MS = 1000
+
+  def read(id: String, delayInMillis: Int = TIMEOUT_IN_MS, runTimeInMillis: Int = RUNTIME_IN_MS)(): Seq[ExecutionTimestamp] = {
+    Thread.sleep(delayInMillis)
+    val start = System.currentTimeMillis()
+    Thread.sleep(runTimeInMillis)
+    val end = System.currentTimeMillis()
+
+    List(ExecutionTimestamp(id, start, end))
+  }
+
+  def process(id: String)(st: Seq[Seq[ExecutionTimestamp]]): Seq[ExecutionTimestamp] =
+    read(id)() ++ st.reduce(_ ++ _)
+
+}


### PR DESCRIPTION
Adding the ability to execute operations in parallel by evaluating nodes as lazy futures.  Tests are a bit hacky but should simulate parallel execution when run in sequence.